### PR TITLE
Fix builds with GCC 4.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -184,7 +184,6 @@ jobs:
       - CXX: g++-4.8
       - CC:  gcc-4.8
       - BUILD_PARALLEL_JOBS: 2
-      - CMAKE_OPTIONS: -DETHASH_BUILD_TESTS=OFF
     docker:
       - image: ethereum/cpp-build-env
     steps:
@@ -193,6 +192,7 @@ jobs:
       - *configure
       - *build
       - *test-cmake-config
+      - *test
 
   linux-clang3.8:
     environment:

--- a/include/ethash/ethash.hpp
+++ b/include/ethash/ethash.hpp
@@ -28,11 +28,11 @@ static constexpr int full_dataset_item_size = ETHASH_FULL_DATASET_ITEM_SIZE;
 
 union hash256
 {
-    uint64_t words[4] = {
-        0,
-    };
+    uint64_t words[4] = {0};
     uint32_t hwords[8];
     char bytes[32];
+
+    constexpr hash256() noexcept : words{0} {}
 
     /// Named constructor from bytes.
     ///

--- a/lib/ethash/ethash-internal.hpp
+++ b/lib/ethash/ethash-internal.hpp
@@ -16,11 +16,11 @@ namespace ethash
 {
 union hash512
 {
-    uint64_t words[8] = {
-        0,
-    };
+    uint64_t words[8] = {0};
     uint32_t half_words[16];
     char bytes[64];
+
+    constexpr hash512() noexcept : words{0} {}
 };
 
 union hash1024


### PR DESCRIPTION
hashXXX structs were not default initialized in GCC 4.8. Explicit constructor fixed this.