### PR TITLE
Preverify

### DIFF
--- a/include/ethash/ethash.hpp
+++ b/include/ethash/ethash.hpp
@@ -109,6 +109,9 @@ result hash_light(
 
 result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce) noexcept;
 
+bool verify_final_hash(const hash256& header_hash, const hash256& mix_hash, uint64_t nonce,
+    const hash256& boundary) noexcept;
+
 bool verify(const epoch_context& context, const hash256& header_hash, const hash256& mix_hash,
     uint64_t nonce, const hash256& boundary) noexcept;
 

--- a/include/ethash/ethash.hpp
+++ b/include/ethash/ethash.hpp
@@ -104,18 +104,19 @@ inline epoch_context_full_ptr create_epoch_context_full(int epoch_number) noexce
     return {ethash_create_epoch_context_full(epoch_number), ethash_destroy_epoch_context_full};
 }
 
-result hash_light(const epoch_context& context, const hash256& header_hash, uint64_t nonce);
+result hash_light(
+    const epoch_context& context, const hash256& header_hash, uint64_t nonce) noexcept;
 
-result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce);
+result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce) noexcept;
 
 bool verify(const epoch_context& context, const hash256& header_hash, const hash256& mix_hash,
-    uint64_t nonce, const hash256& boundary);
+    uint64_t nonce, const hash256& boundary) noexcept;
 
 uint64_t search_light(const epoch_context& context, const hash256& header_hash,
-    const hash256& boundary, uint64_t start_nonce, size_t iterations);
+    const hash256& boundary, uint64_t start_nonce, size_t iterations) noexcept;
 
 uint64_t search(const epoch_context_full& context, const hash256& header_hash,
-    const hash256& boundary, uint64_t start_nonce, size_t iterations);
+    const hash256& boundary, uint64_t start_nonce, size_t iterations) noexcept;
 
 
 /// Tries to find the epoch number matching the given seed hash.

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -277,13 +277,18 @@ result hash(const epoch_context_full& context, const hash256& header_hash, uint6
     return {hash_final(seed, mix_hash), mix_hash};
 }
 
+bool verify_final_hash(const hash256& header_hash, const hash256& mix_hash, uint64_t nonce,
+    const hash256& boundary) noexcept
+{
+    const hash512 seed = hash_seed(header_hash, nonce);
+    return is_less_or_equal(hash_final(seed, mix_hash), boundary);
+}
+
 bool verify(const epoch_context& context, const hash256& header_hash, const hash256& mix_hash,
     uint64_t nonce, const hash256& boundary) noexcept
 {
     const hash512 seed = hash_seed(header_hash, nonce);
-    const hash256 final_hash = hash_final(seed, mix_hash);
-
-    if (!is_less_or_equal(final_hash, boundary))
+    if (!is_less_or_equal(hash_final(seed, mix_hash), boundary))
         return false;
 
     const hash256 expected_mix_hash = hash_kernel(context, seed, calculate_dataset_item);

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -209,6 +209,14 @@ inline hash512 hash_seed(const hash256& header_hash, uint64_t nonce) noexcept
     return keccak512(init_data, sizeof(init_data));
 }
 
+inline hash256 hash_final(const hash512& seed, const hash256& mix_hash)
+{
+    uint8_t final_data[sizeof(seed) + sizeof(mix_hash)];
+    std::memcpy(&final_data[0], seed.bytes, sizeof(seed));
+    std::memcpy(&final_data[sizeof(seed)], mix_hash.bytes, sizeof(mix_hash));
+    return keccak256(final_data, sizeof(final_data));
+}
+
 inline result hash_kernel(
     const epoch_context& context, const hash256& header_hash, uint64_t nonce, lookup_fn lookup)
 {
@@ -242,11 +250,7 @@ inline result hash_kernel(
     }
     mix_hash = fix_endianness32(mix_hash);
 
-    uint8_t final_data[sizeof(s) + sizeof(mix_hash)];
-    std::memcpy(&final_data[0], s.bytes, sizeof(s));
-    std::memcpy(&final_data[sizeof(s)], mix_hash.bytes, sizeof(mix_hash));
-    hash256 final_hash = keccak256(final_data, sizeof(final_data));
-    return {final_hash, mix_hash};
+    return {hash_final(s, mix_hash), mix_hash};
 }
 }
 

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -217,7 +217,8 @@ inline hash256 hash_final(const hash512& seed, const hash256& mix_hash)
     return keccak256(final_data, sizeof(final_data));
 }
 
-inline hash256 hash_kernel(const epoch_context& context, const hash512& seed, lookup_fn lookup)
+inline hash256 hash_kernel(
+    const epoch_context& context, const hash512& seed, lookup_fn lookup) noexcept
 {
     static constexpr size_t mix_hwords = sizeof(hash1024) / sizeof(uint32_t);
     const uint32_t index_limit = static_cast<uint32_t>(context.full_dataset_num_items);
@@ -249,14 +250,14 @@ inline hash256 hash_kernel(const epoch_context& context, const hash512& seed, lo
 }
 }
 
-result hash_light(const epoch_context& context, const hash256& header_hash, uint64_t nonce)
+result hash_light(const epoch_context& context, const hash256& header_hash, uint64_t nonce) noexcept
 {
     const hash512 seed = hash_seed(header_hash, nonce);
     const hash256 mix_hash = hash_kernel(context, seed, calculate_dataset_item);
     return {hash_final(seed, mix_hash), mix_hash};
 }
 
-result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce)
+result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce) noexcept
 {
     static const auto lazy_lookup = [](const epoch_context& context, size_t index) noexcept
     {
@@ -277,7 +278,7 @@ result hash(const epoch_context_full& context, const hash256& header_hash, uint6
 }
 
 bool verify(const epoch_context& context, const hash256& header_hash, const hash256& mix_hash,
-    uint64_t nonce, const hash256& boundary)
+    uint64_t nonce, const hash256& boundary) noexcept
 {
     const hash512 seed = hash_seed(header_hash, nonce);
     const hash256 final_hash = hash_final(seed, mix_hash);
@@ -290,7 +291,7 @@ bool verify(const epoch_context& context, const hash256& header_hash, const hash
 }
 
 uint64_t search_light(const epoch_context& context, const hash256& header_hash,
-    const hash256& boundary, uint64_t start_nonce, size_t iterations)
+    const hash256& boundary, uint64_t start_nonce, size_t iterations) noexcept
 {
     const uint64_t end_nonce = start_nonce + iterations;
     for (uint64_t nonce = start_nonce; nonce < end_nonce; ++nonce)
@@ -303,7 +304,7 @@ uint64_t search_light(const epoch_context& context, const hash256& header_hash,
 }
 
 uint64_t search(const epoch_context_full& context, const hash256& header_hash,
-    const hash256& boundary, uint64_t start_nonce, size_t iterations)
+    const hash256& boundary, uint64_t start_nonce, size_t iterations) noexcept
 {
     const uint64_t end_nonce = start_nonce + iterations;
     for (uint64_t nonce = start_nonce; nonce < end_nonce; ++nonce)

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -224,16 +224,16 @@ inline result hash_kernel(
     const int num_items = context.full_dataset_num_items;
     const uint32_t index_limit = static_cast<uint32_t>(num_items);
 
-    const hash512 s = hash_seed(header_hash, nonce);
-    const uint32_t s_init = fix_endianness(s.half_words[0]);
+    const hash512 seed = hash_seed(header_hash, nonce);
+    const uint32_t seed_init = fix_endianness(seed.half_words[0]);
 
     hash1024 mix;
-    mix.hashes[0] = fix_endianness32(s);
-    mix.hashes[1] = fix_endianness32(s);
+    mix.hashes[0] = fix_endianness32(seed);
+    mix.hashes[1] = fix_endianness32(seed);
 
     for (uint32_t i = 0; i < num_dataset_accesses; ++i)
     {
-        auto p = fnv(i ^ s_init, mix.hwords[i % mix_hwords]) % index_limit;
+        auto p = fnv(i ^ seed_init, mix.hwords[i % mix_hwords]) % index_limit;
         hash1024 newdata = fix_endianness32(lookup(context, p));
 
         for (size_t j = 0; j < mix_hwords; ++j)
@@ -250,7 +250,7 @@ inline result hash_kernel(
     }
     mix_hash = fix_endianness32(mix_hash);
 
-    return {hash_final(s, mix_hash), mix_hash};
+    return {hash_final(seed, mix_hash), mix_hash};
 }
 }
 

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -217,14 +217,10 @@ inline hash256 hash_final(const hash512& seed, const hash256& mix_hash)
     return keccak256(final_data, sizeof(final_data));
 }
 
-inline result hash_kernel(
-    const epoch_context& context, const hash256& header_hash, uint64_t nonce, lookup_fn lookup)
+inline result hash_kernel(const epoch_context& context, const hash512& seed, lookup_fn lookup)
 {
     static constexpr size_t mix_hwords = sizeof(hash1024) / sizeof(uint32_t);
-    const int num_items = context.full_dataset_num_items;
-    const uint32_t index_limit = static_cast<uint32_t>(num_items);
-
-    const hash512 seed = hash_seed(header_hash, nonce);
+    const uint32_t index_limit = static_cast<uint32_t>(context.full_dataset_num_items);
     const uint32_t seed_init = fix_endianness(seed.half_words[0]);
 
     hash1024 mix;
@@ -256,7 +252,7 @@ inline result hash_kernel(
 
 result hash_light(const epoch_context& context, const hash256& header_hash, uint64_t nonce)
 {
-    return hash_kernel(context, header_hash, nonce, calculate_dataset_item);
+    return hash_kernel(context, hash_seed(header_hash, nonce), calculate_dataset_item);
 }
 
 result hash(const epoch_context_full& context, const hash256& header_hash, uint64_t nonce)
@@ -274,7 +270,7 @@ result hash(const epoch_context_full& context, const hash256& header_hash, uint6
         return item;
     };
 
-    return hash_kernel(context, header_hash, nonce, lazy_lookup);
+    return hash_kernel(context, hash_seed(header_hash, nonce), lazy_lookup);
 }
 
 bool verify(const epoch_context& context, const hash256& header_hash, const hash256& mix_hash,

--- a/test/benchmarks/benchmarks.cpp
+++ b/test/benchmarks/benchmarks.cpp
@@ -79,6 +79,21 @@ static void calculate_dataset_item(benchmark::State& state)
 BENCHMARK(calculate_dataset_item);
 
 
+static void hash(benchmark::State& state)
+{
+    const int block_number = 5000000;
+    const ethash::hash256 header_hash =
+        to_hash256("bc544c2baba832600013bd5d1983f592e9557d04b0fb5ef7a100434a5fc8d52a");
+    const uint64_t nonce = 0x4617a20003ba3f25;
+
+    static const auto ctx = ethash::create_epoch_context(ethash::get_epoch_number(block_number));
+
+    for (auto _ : state)
+        ethash::hash_light(*ctx, header_hash, nonce);
+}
+BENCHMARK(hash);
+
+
 static void verify(benchmark::State& state)
 {
     const int block_number = 5000000;
@@ -95,7 +110,26 @@ static void verify(benchmark::State& state)
     for (auto _ : state)
         ethash::verify(*ctx, header_hash, mix_hash, nonce, boundry);
 }
-BENCHMARK(verify)->Threads(1)->Threads(2)->Threads(4)->Threads(8);
+BENCHMARK(verify);
+
+
+static void verify_mt(benchmark::State& state)
+{
+    const int block_number = 5000000;
+    const ethash::hash256 header_hash =
+        to_hash256("bc544c2baba832600013bd5d1983f592e9557d04b0fb5ef7a100434a5fc8d52a");
+    const ethash::hash256 mix_hash =
+        to_hash256("94cd4e844619ee20989578276a0a9046877d569d37ba076bf2e8e34f76189dea");
+    const uint64_t nonce = 0x4617a20003ba3f25;
+    const ethash::hash256 boundry =
+        to_hash256("0000000000001a5c000000000000000000000000000000000000000000000000");
+
+    static const auto ctx = ethash::create_epoch_context(ethash::get_epoch_number(block_number));
+
+    for (auto _ : state)
+        ethash::verify(*ctx, header_hash, mix_hash, nonce, boundry);
+}
+BENCHMARK(verify_mt)->Threads(1)->Threads(2)->Threads(4)->Threads(8);
 
 
 static void verify_managed(benchmark::State& state)

--- a/test/unittests/test_ethash.cpp
+++ b/test/unittests/test_ethash.cpp
@@ -600,9 +600,13 @@ TEST(ethash, verify_hash_light)
         EXPECT_EQ(to_hex(r.final_hash), t.final_hash_hex);
         EXPECT_EQ(to_hex(r.mix_hash), t.mix_hash_hex);
 
-        bool v = verify(*context, header_hash, mix_hash, nonce, boundary);
+        bool v = verify_final_hash(header_hash, mix_hash, nonce, boundary);
+        EXPECT_TRUE(v);
+        v = verify(*context, header_hash, mix_hash, nonce, boundary);
         EXPECT_TRUE(v);
 
+        v = verify_final_hash(header_hash, mix_hash, nonce + 1, boundary);
+        EXPECT_FALSE(v);
         v = verify(*context, header_hash, mix_hash, nonce + 1, boundary);
         EXPECT_FALSE(v);
     }
@@ -633,6 +637,19 @@ TEST(ethash, verify_hash)
         EXPECT_EQ(to_hex(r.final_hash), t.final_hash_hex);
         EXPECT_EQ(to_hex(r.mix_hash), t.mix_hash_hex);
     }
+}
+
+TEST(ethash, verify_final_hash_only)
+{
+    auto context = create_epoch_context(0);
+    const hash256 header_hash = {};
+    const hash256 mix_hash = {};
+    uint64_t nonce = 3221208;
+    const hash256 boundary =
+        to_hash256("000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+    EXPECT_TRUE(verify_final_hash(header_hash, mix_hash, nonce, boundary));
+    EXPECT_FALSE(verify(*context, header_hash, mix_hash, nonce, boundary));
 }
 
 TEST(ethash, verify_boundary)


### PR DESCRIPTION
Add function `verify_final_hash()` that only checks the last step of full ethash hash. This does not need access to ethash light cache and can be used as preliminary test to block headers.