### PR TITLE
progpow: Add keccak_progpow() hash function

### DIFF
--- a/lib/ethash/CMakeLists.txt
+++ b/lib/ethash/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(
     kiss99.h
     primes.h
     primes.c
+    progpow-internal.hpp
+    progpow.cpp
 )
 
 target_include_directories(ethash PUBLIC $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:include>)

--- a/lib/ethash/progpow-internal.hpp
+++ b/lib/ethash/progpow-internal.hpp
@@ -1,0 +1,32 @@
+// ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+// Copyright 2018 Pawel Bylica.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+#pragma once
+
+#include <ethash/hash_types.hpp>
+
+namespace progpow
+{
+using namespace ethash;
+
+/// A variant of Keccak hash function for ProgPoW.
+///
+/// This Keccak hash function uses 800-bit permutation (Keccak-f[800]) with 448 bitrate what
+/// gives 176-bit output size. This function over-extends the output and takes 256 bits
+/// of the Keccak state.
+/// It take exactly 448 bits of input (split across 3 arguments) and adds no padding.
+///
+/// @param header_hash  The 256-bit header hash.
+/// @param nonce        The 64-bit nonce.
+/// @param extra        Additional 128-bits of optional data. If null pointer null bytes are
+///                     used instead.
+/// @return             The 256-bit output of the hash function.
+hash256 keccak_progpow_256(
+    const hash256& header_hash, uint64_t nonce, const uint32_t* extra) noexcept;
+
+/// The same as keccak_progpow_256() but returns only 64-bit output.
+uint64_t keccak_progpow_64(
+    const hash256& header_hash, uint64_t nonce, const uint32_t* extra) noexcept;
+
+}  // namespace progpow

--- a/lib/ethash/progpow.cpp
+++ b/lib/ethash/progpow.cpp
@@ -1,0 +1,48 @@
+// ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+// Copyright 2018 Pawel Bylica.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+#include "progpow-internal.hpp"
+
+#include "endianness.hpp"
+
+#include <ethash/keccak.h>
+
+namespace progpow
+{
+hash256 keccak_progpow_256(
+    const hash256& header_hash, uint64_t nonce, const uint32_t extra[4]) noexcept
+{
+    static constexpr size_t num_words = sizeof(header_hash.hwords) / sizeof(header_hash.hwords[0]);
+
+    uint32_t state[25] = {};
+
+    size_t i;
+    for (i = 0; i < num_words; ++i)
+        state[i] = le::uint32(header_hash.hwords[i]);
+
+    state[i++] = static_cast<uint32_t>(nonce);
+    state[i++] = static_cast<uint32_t>(nonce >> 32);
+
+    if (extra)
+    {
+        for (int j = 0; j < 4; ++j)
+            state[i++] = extra[j];
+    }
+
+    ethash_keccakf800(state);
+
+    hash256 output;
+    for (i = 0; i < num_words; ++i)
+        output.hwords[i] = state[i];
+    return output;
+}
+
+uint64_t keccak_progpow_64(
+    const hash256 &header_hash, uint64_t nonce, const uint32_t *extra) noexcept
+{
+    const hash256 h = keccak_progpow_256(header_hash, nonce, extra);
+    return (uint64_t(h.hwords[0]) << 32) | h.hwords[1];
+}
+
+}  // namespace progpow

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
     test_kiss.cpp
     test_managed.cpp
     test_primes.cpp
+    test_progpow.cpp
 )
 
 target_link_libraries(ethash-test PRIVATE ethash GTest::gtest GTest::main)

--- a/test/unittests/test_progpow.cpp
+++ b/test/unittests/test_progpow.cpp
@@ -1,0 +1,25 @@
+// ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+// Copyright 2018 Pawel Bylica.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+#include <ethash/progpow-internal.hpp>
+
+#include "helpers.hpp"
+
+#include <gtest/gtest.h>
+
+
+TEST(progpow, keccak_progpow_64)
+{
+    const uint32_t extra_1[4] = {};
+    const auto h0 = progpow::keccak_progpow_64({}, 0, nullptr);
+    const auto h1 = progpow::keccak_progpow_64({}, 0, extra_1);
+    EXPECT_EQ(h0, h1);
+    EXPECT_EQ(h0, 0xe531d45df404c6fb);
+
+    const ethash::hash256 header_hash_2 =
+        to_hash256("bc544c2baba832600013bd5d1983f592e9557d04b0fb5ef7a100434a5fc8d52a");
+    const uint32_t extra_2[4] = {1, 2, 3, 4};
+    const auto h2 = progpow::keccak_progpow_64(header_hash_2, 0x1ffffffff, extra_2);
+    EXPECT_EQ(h2, 0x4e7abe6fa3fc5004);
+}


### PR DESCRIPTION
I tried to implement the special keccak variant used in ProgPoW (see https://ethereum-magicians.org/t/eip-progpow-a-programmatic-proof-of-work/272/10?u=chfast).

Following the "spec" it gives different results on big-endian architectures. See the additional `fix_endianness` used in the implementation.

cc @OhGodAGirl, @ifdefelse.