### PR TITLE
Add Python package/bindings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -23,3 +23,4 @@ values =
 
 [bumpversion:file:include/ethash/version.h]
 
+[bumpversion:file:setup.py]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /build
 /cmake-build-*
 /.idea
+
+/dist
+/.eggs
+/bindings/python/**/*.egg-info
+/bindings/python/**/*.pyc
+/bindings/python/**/*.so

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CMakeLists.txt
+recursive-include cmake *
+recursive-include include *
+recursive-include lib *

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,27 +13,28 @@ environment:
     secure: agYfiC1OKfHnGOJQolOBorIRovVTgDW3TJ8JOb2+0XZiAnNwbrtPegxaaFM8/VWu
   matrix:
     - ARCH: amd64
-      CONFIGURATION: Debug
-    - ARCH: x86
-    - ARCH: amd64
+      PYTHON: true
+#    - ARCH: amd64
+#      CONFIGURATION: Debug
+#    - ARCH: x86
+#    - ARCH: amd64
 
 install:
-  # Python 3
-  - set PATH_ORIG=%PATH%
-  - set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH_ORIG%
+  # Set default Python version.
+  - set PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
   - pip install requests
 
 before_build:
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=%ARCH%
-  - if not exist build mkdir build
-  - cd build
-  - cmake -GNinja .. -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DHUNTER_CONFIGURATION_TYPES=%CONFIGURATION%
+  - cmake -S . -B build -G Ninja .. -Wno-dev -DCMAKE_INSTALL_PREFIX=./dist -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DHUNTER_CONFIGURATION_TYPES=%CONFIGURATION%
 
 build_script:
-  - cmake --build . --target install
+  - cmake --build build --target install
+  - if defined PYTHON bash scripts/ci/python_build_wheels.sh
 
 test_script:
-  - if %CONFIGURATION%==Release C:\projects\ethash\build\test\ethash-test.exe
+  #- if %CONFIGURATION%==Release C:\projects\ethash\build\test\ethash-test.exe
+  - if defined PYTHON (set ETHASH_PYTHON_SKIP_BUILD=1 && python setup.py test)
 
 artifacts:
   - path: dist

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,9 @@ environment:
   matrix:
     - ARCH: amd64
       PYTHON: true
-#    - ARCH: amd64
-#      CONFIGURATION: Debug
-#    - ARCH: x86
-#    - ARCH: amd64
+    - ARCH: amd64
+      CONFIGURATION: Debug
+    - ARCH: x86
 
 install:
   # Set default Python version.
@@ -33,7 +32,7 @@ build_script:
   - if defined PYTHON bash scripts/ci/python_build_wheels.sh
 
 test_script:
-  #- if %CONFIGURATION%==Release C:\projects\ethash\build\test\ethash-test.exe
+  - if %CONFIGURATION%==Release C:\projects\ethash\build\test\ethash-test.exe
   - if defined PYTHON (set ETHASH_PYTHON_SKIP_BUILD=1 && python setup.py test)
 
 artifacts:

--- a/bindings/python/ethash/__init__.py
+++ b/bindings/python/ethash/__init__.py
@@ -1,0 +1,15 @@
+# ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+from _ethash import ffi, lib
+
+
+def keccak_256(data):
+    hash = lib.ethash_keccak256(ffi.from_buffer(data), len(data))
+    return ffi.unpack(hash.str, len(hash.str))
+
+
+def keccak_512(data):
+    hash = lib.ethash_keccak512(ffi.from_buffer(data), len(data))
+    return ffi.unpack(hash.str, len(hash.str))

--- a/bindings/python/ethash/_build.py
+++ b/bindings/python/ethash/_build.py
@@ -1,0 +1,47 @@
+# ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+# The CFFI build script for ethash library.
+# It expects the library is installed in the dist/ directory.
+# The installation can be performed by
+#
+#     cmake . -DCMAKE_INSTALL_PREFIX=dist
+#     make
+#     make install
+
+from cffi import FFI
+
+ffibuilder = FFI()
+
+ffibuilder.set_source(
+    "_ethash",
+    r"""
+    #include <ethash/keccak.h>
+     """,
+    include_dirs=['include'],
+    libraries=['ethash', 'keccak'],
+)
+
+ffibuilder.cdef("""
+
+union ethash_hash256
+{
+    ...;
+    char str[32];
+};
+
+union ethash_hash512
+{
+    ...;
+    char str[64];
+};
+
+union ethash_hash256 ethash_keccak256(const uint8_t* data, size_t size);
+
+union ethash_hash512 ethash_keccak512(const uint8_t* data, size_t size);
+
+""")
+
+if __name__ == "__main__":
+    ffibuilder.compile(verbose=True)

--- a/bindings/python/tests/test_ethash.py
+++ b/bindings/python/tests/test_ethash.py
@@ -1,0 +1,25 @@
+# ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+import unittest
+
+import ethash
+
+
+class TestEthash(unittest.TestCase):
+
+    def test_keccak(self):
+        h256 = ('c5d2460186f7233c927e7db2dcc703c0'
+                'e500b653ca82273b7bfad8045d85a470')
+        h512 = ('0eab42de4c3ceb9235fc91acffe746b2'
+                '9c29a8c366b7c60e4e67c466f36a4304'
+                'c00fa9caf9d87976ba469bcbe06713b4'
+                '35f091ef2769fb160cdab33d3670680e')
+
+        self.assertEqual(ethash.keccak_256(b'').hex(), h256)
+        self.assertEqual(ethash.keccak_512(b'').hex(), h512)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/circle.yml
+++ b/circle.yml
@@ -246,6 +246,61 @@ jobs:
           command: |  # Software emulation in qemu will not handle threads.
             qemu-ppc64-static test/ethash-test --gtest_filter='-*_multithreaded.*'
 
+  linux-release:
+    environment:
+      - CXX: clang++-8
+      - CC:  clang-8
+      - BUILD_PARALLEL_JOBS: 4
+      - CMAKE_OPTIONS: -DETHASH_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DHUNTER_ENABLED=OFF
+    docker:
+      - image: ethereum/cpp-build-env:9
+    steps:
+      - checkout
+      - *configure
+      - *build
+      - persist_to_workspace:
+          root: /tmp/local
+          paths:
+            - "*"
+
+  linux-release-python:
+    docker:
+      - image: quay.io/pypa/manylinux1_x86_64
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/project/dist
+      - run:
+          name: "Build wheels"
+          command: sh scripts/ci/python_build_wheels.sh
+      - run:
+          name: "Tag wheels"
+          working_directory: ~/project/dist
+          command: |
+            find -name '*linux_x86_64.whl' -exec auditwheel repair {} \;
+      - store_artifacts:
+          path: ~/project/dist
+          destination: dist
+      - run:
+          name: "Install CMake"
+          command: |
+            export PATH=/opt/python/cp37-cp37m/bin:$PATH
+            pip install cmake
+      - run:
+          name: "Build source dist"
+          command: |
+            export PATH=/opt/python/cp37-cp37m/bin:$PATH
+            ./setup.py sdist
+      - run:
+          name: "Build wheel with CMake build"
+          command: |
+            export PATH=/opt/python/cp37-cp37m/bin:$PATH
+            ./setup.py bdist_wheel
+      - run:
+          name: "Test"
+          command: |
+            export PATH=/opt/python/cp37-cp37m/bin:$PATH
+            ./setup.py test
 
   macos-xcode-tsan:
     <<: *macos-defaults
@@ -261,6 +316,34 @@ jobs:
     macos:
       xcode: "8.3.3"
 
+  macos-release:
+    environment:
+      - BUILD_PARALLEL_JOBS: 4
+      - CMAKE_OPTIONS: -DETHASH_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=~/project/dist
+    macos:
+      xcode: "10.2.1"
+    steps:
+      - run:
+          name: "Install CMake"
+          command: |
+            which python3
+            ls -l /usr/local/lib
+            ls -l /usr/local/bin
+            pip3 install cmake
+      - checkout
+      - *configure
+      - *build
+      - run:
+          name: "Test"
+          command: |
+            ./setup.py test
+      - run:
+          name: "Build wheels"
+          command: sh scripts/ci/python_build_wheels.sh
+      - store_artifacts:
+          path: ~/project/dist
+          destination: dist
+
 
 workflows:
   version: 2
@@ -275,3 +358,8 @@ workflows:
       - powerpc64
       - macos-xcode-tsan
       - macos-xcode83
+      - linux-release
+      - linux-release-python:
+          requires:
+            - linux-release
+      - macos-release

--- a/scripts/ci/python_build_wheels.sh
+++ b/scripts/ci/python_build_wheels.sh
@@ -1,24 +1,33 @@
 #!/usr/bin/env bash
+# -*- coding: utf-8 -*-
 
 # ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
 # Copyright 2019 Pawel Bylica.
 # Licensed under the Apache License, Version 2.0.
 
-set -e
+set -eo pipefail
 
 if [ -n "$APPVEYOR" ]; then
-    PYTHON_PATHS="/c/Python37-x64:/c/Python37-x64/Scripts /c/Python36-x64:/c/Python36-x64/Scripts /c/Python35-x64:/c/Python35-x64/Scripts"
+    PYTHON_PATHS="/c/Python37-x64 /c/Python36-x64 /c/Python35-x64"
+elif [ -n "$CIRCLECI" ]; then
+    if [ "$OSTYPE" = "linux-gnu" ]; then
+        PYTHON_PATHS="/opt/python/cp37-cp37m/bin /opt/python/cp36-cp36m/bin /opt/python/cp35-cp35m/bin"
+    else
+        ln -s /usr/local/Cellar/python/3.7.3/bin/python3 /usr/local/Cellar/python/3.7.3/bin/python
+        PYTHON_PATHS="/usr/local/Cellar/python/3.7.3/bin"
+    fi
 fi
 
 PATH_ORIG=$PATH
 for p in $PYTHON_PATHS
 do
-    export PATH="$p:$PATH_ORIG"
+    PATH="$p:$PATH_ORIG"
     echo '***'
     python --version
+    which python
+    python -m pip --version
     echo '***'
-    pip --version
-    pip install wheel
+    python -m pip install wheel
     python setup.py build_ext --skip-cmake-build
     python setup.py bdist_wheel --skip-build
 done

--- a/scripts/ci/python_build_wheels.sh
+++ b/scripts/ci/python_build_wheels.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+set -e
+
+if [ -n "$APPVEYOR" ]; then
+    PYTHON_PATHS="/c/Python37-x64:/c/Python37-x64/Scripts /c/Python36-x64:/c/Python36-x64/Scripts /c/Python35-x64:/c/Python35-x64/Scripts"
+fi
+
+PATH_ORIG=$PATH
+for p in $PYTHON_PATHS
+do
+    export PATH="$p:$PATH_ORIG"
+    echo '***'
+    python --version
+    echo '***'
+    pip --version
+    pip install wheel
+    python setup.py build_ext --skip-cmake-build
+    python setup.py bdist_wheel --skip-build
+done

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
+# Copyright 2019 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0.
+
+import os
+import subprocess
+import shutil
+from distutils.errors import CCompilerError
+from os import path
+
+from setuptools import setup
+from setuptools.command.build_ext import build_ext as setuptools_build_ext
+
+
+class build_ext(setuptools_build_ext):
+    user_options = setuptools_build_ext.user_options + [
+        ('skip-cmake-build', None,
+         "Skip CMake build assuming the libraries are already installed " +
+         "to the dist directory")
+    ]
+
+    def initialize_options(self):
+        super(build_ext, self).initialize_options()
+        self.skip_cmake_build = False
+
+    def run(self):
+        build_dir = self.build_temp
+        source_dir = path.dirname(path.abspath(__file__))
+        install_dir = path.join(source_dir, 'dist')
+
+        cmake_opts = [
+            '-DCMAKE_INSTALL_PREFIX={}'.format(install_dir),
+            '-DCMAKE_INSTALL_LIBDIR=lib',
+            '-DCMAKE_POSITION_INDEPENDENT_CODE=TRUE',
+            '-DHUNTER_ENABLED=OFF',
+            '-DETHASH_BUILD_TESTS=OFF',
+            '-DETHASH_INSTALL_CMAKE_CONFIG=OFF'
+        ]
+
+        generator = os.environ.get('GENERATOR')
+        if generator:
+            cmake_opts.append('-G{}'.format(generator))
+
+        if not self.skip_cmake_build and not os.environ.get('ETHASH_PYTHON_SKIP_BUILD'):
+            cmake_cmd = shutil.which('cmake')
+            if not cmake_cmd:
+                raise CCompilerError(
+                    "cmake tool not found but required to build this package")
+
+            r = subprocess.call([cmake_cmd, source_dir] + cmake_opts,
+                                cwd=build_dir)
+            if r != 0:
+                raise CCompilerError(
+                    "cmake configuration failed with exit status {}".format(r))
+            r = subprocess.call(
+                [cmake_cmd, '--build', build_dir, '--target', 'install',
+                 '--config', 'Release'])
+            if r != 0:
+                raise CCompilerError(
+                    "cmake build failed with exit status {}".format(r))
+
+        self.library_dirs.append(path.join(install_dir, 'lib'))
+
+        super(build_ext, self).run()
+
+
+setup(
+    name='ethash',
+    # FIXME: Sync version with bumpversion.
+    version='0.5.1-alpha.0',
+    url='https://github.com/chfast/ethash',
+    author='Paweł Bylica',
+    author_email='pawel@ethereum.org',
+
+    package_dir={'': 'bindings/python'},
+    packages=['ethash'],
+    cffi_modules=['bindings/python/ethash/_build.py:ffibuilder'],
+
+    setup_requires=['cffi>=1.12'],
+    install_requires=['cffi>=1.12'],
+
+    test_suite='tests.test_ethash',
+
+    cmdclass={'build_ext': build_ext},
+)


### PR DESCRIPTION
It adds CFFI based Python bindings to the library and setup scripts for Python packaging.

Only keccak functions are exported for now. This PR is more about setup.

The Python setup requires the library to be prebuilt and placed in the `dist/lib` dir. This is easy to do on CIs, but will not allow installing the package "from source".