### PR TITLE
keccak: Optimize Keccak with BMI extension

### DIFF
--- a/include/ethash/keccak.h
+++ b/include/ethash/keccak.h
@@ -29,6 +29,10 @@ extern "C" {
  */
 void ethash_keccakf1600(uint64_t state[25]) NOEXCEPT;
 
+/// Variant of ethash_keccakf1600() with additional optimization provided by BMI and BMI2
+/// instruction set extensions. May only be used on hardware supporting these extensions.
+void ethash_keccakf1600_bmi(uint64_t state[25]) NOEXCEPT;
+
 /**
  * The Keccak-f[800] function.
  *

--- a/include/ethash/keccak.h
+++ b/include/ethash/keccak.h
@@ -19,6 +19,11 @@
 extern "C" {
 #endif
 
+typedef void (*ethash_keccakf1600_func)(uint64_t[25]);
+
+/// The pointer to the Keccak-f[1600] function implementation.
+extern ethash_keccakf1600_func ethash_keccakf1600;
+
 /**
  * The Keccak-f[1600] function.
  *
@@ -27,7 +32,7 @@ extern "C" {
  *
  * @param state  The state of 25 64-bit words on which the permutation is to be performed.
  */
-void ethash_keccakf1600(uint64_t state[25]) NOEXCEPT;
+void ethash_keccakf1600_generic(uint64_t state[25]) NOEXCEPT;
 
 /// Variant of ethash_keccakf1600() with additional optimization provided by BMI and BMI2
 /// instruction set extensions. May only be used on hardware supporting these extensions.

--- a/lib/keccak/keccakf1600.c
+++ b/lib/keccak/keccakf1600.c
@@ -269,4 +269,10 @@ __attribute__((target("bmi,bmi2"))) void ethash_keccakf1600_bmi(uint64_t state[2
 {
     keccakf1600_implementation(state);
 }
+
+__attribute__((constructor)) static void select_keccakf1600_implementation()
+{
+    if (__builtin_cpu_supports("bmi2"))
+        ethash_keccakf1600 = ethash_keccakf1600_bmi;
+}
 #endif

--- a/lib/keccak/keccakf1600.c
+++ b/lib/keccak/keccakf1600.c
@@ -257,10 +257,12 @@ static inline ALWAYS_INLINE void keccakf1600_implementation(uint64_t state[25])
     state[24] = Asu;
 }
 
-void ethash_keccakf1600(uint64_t state[25])
+void ethash_keccakf1600_generic(uint64_t state[25])
 {
     keccakf1600_implementation(state);
 }
+
+ethash_keccakf1600_func ethash_keccakf1600 = ethash_keccakf1600_generic;
 
 #if defined(__x86_64__) && __has_attribute(target)
 __attribute__((target("bmi,bmi2"))) void ethash_keccakf1600_bmi(uint64_t state[25])

--- a/lib/keccak/keccakf1600.c
+++ b/lib/keccak/keccakf1600.c
@@ -261,3 +261,10 @@ void ethash_keccakf1600(uint64_t state[25])
 {
     keccakf1600_implementation(state);
 }
+
+#if defined(__x86_64__) && __has_attribute(target)
+__attribute__((target("bmi,bmi2"))) void ethash_keccakf1600_bmi(uint64_t state[25])
+{
+    keccakf1600_implementation(state);
+}
+#endif

--- a/lib/keccak/keccakf1600.c
+++ b/lib/keccak/keccakf1600.c
@@ -2,6 +2,7 @@
 // Copyright 2018-2019 Pawel Bylica.
 // Licensed under the Apache License, Version 2.0.
 
+#include "../support/attributes.h"
 #include <ethash/keccak.h>
 
 /// Rotates the bits of x left by the count value specified by s.
@@ -43,7 +44,7 @@ static const uint64_t round_constants[24] = {
 /// The implementation based on:
 /// - "simple" implementation by Ronny Van Keer, included in "Reference and optimized code in C",
 ///   https://keccak.team/archives.html, CC0-1.0 / Public Domain.
-void ethash_keccakf1600(uint64_t state[25])
+static inline ALWAYS_INLINE void keccakf1600_implementation(uint64_t state[25])
 {
     uint64_t Aba, Abe, Abi, Abo, Abu;
     uint64_t Aga, Age, Agi, Ago, Agu;
@@ -254,4 +255,9 @@ void ethash_keccakf1600(uint64_t state[25])
     state[22] = Asi;
     state[23] = Aso;
     state[24] = Asu;
+}
+
+void ethash_keccakf1600(uint64_t state[25])
+{
+    keccakf1600_implementation(state);
 }

--- a/lib/keccak/keccakf1600.c
+++ b/lib/keccak/keccakf1600.c
@@ -88,7 +88,7 @@ static inline ALWAYS_INLINE void keccakf1600_implementation(uint64_t state[25])
     Aso = state[23];
     Asu = state[24];
 
-    for (int round = 0; round < 24; round += 2)
+    for (size_t round = 0; round < 24; round += 2)
     {
         /* Round (round + 0): Axx -> Exx */
 

--- a/lib/support/attributes.h
+++ b/lib/support/attributes.h
@@ -4,22 +4,23 @@
 
 #pragma once
 
+// Provide __has_attribute macro if not defined.
+#ifndef __has_attribute
+#define __has_attribute(name) 0
+#endif
+
 // [[always_inline]]
 #if _MSC_VER
 #define ALWAYS_INLINE __forceinline
-#elif defined(__has_attribute)
-#if __has_attribute(always_inline)
+#elif __has_attribute(always_inline)
 #define ALWAYS_INLINE __attribute__((always_inline))
-#endif
-#endif
-#if !defined(ALWAYS_INLINE)
+#else
 #define ALWAYS_INLINE
 #endif
 
 // [[no_sanitize()]]
 #if __clang__
-#define NO_SANITIZE(sanitizer) \
-    __attribute__((no_sanitize(sanitizer)))
+#define NO_SANITIZE(sanitizer) __attribute__((no_sanitize(sanitizer)))
 #else
 #define NO_SANITIZE(sanitizer)
 #endif

--- a/test/benchmarks/keccak_benchmarks.cpp
+++ b/test/benchmarks/keccak_benchmarks.cpp
@@ -14,6 +14,10 @@ void fake_keccakf1600(uint64_t* state) noexcept
     (void)state;
 }
 
+inline void best(uint64_t state[25]) noexcept
+{
+    ethash_keccakf1600(state);
+}
 
 template <void Fn(uint64_t*)>
 static void keccakf1600(benchmark::State& state)
@@ -26,10 +30,11 @@ static void keccakf1600(benchmark::State& state)
         benchmark::DoNotOptimize(keccak_state);
     }
 }
-BENCHMARK_TEMPLATE(keccakf1600, ethash_keccakf1600);
+BENCHMARK_TEMPLATE(keccakf1600, ethash_keccakf1600_generic);
 #if defined(__x86_64__) && __has_attribute(target)
 BENCHMARK_TEMPLATE(keccakf1600, ethash_keccakf1600_bmi);
 #endif
+BENCHMARK_TEMPLATE(keccakf1600, best);
 
 
 static void keccakf800(benchmark::State& state)

--- a/test/benchmarks/keccak_benchmarks.cpp
+++ b/test/benchmarks/keccak_benchmarks.cpp
@@ -3,11 +3,9 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include "keccak_utils.hpp"
-
-#include <ethash/keccak.h>
-#include <ethash/keccak.hpp>
-
+#include "support/attributes.h"
 #include <benchmark/benchmark.h>
+#include <ethash/keccak.h>
 
 
 void fake_keccakf1600(uint64_t* state) noexcept
@@ -17,17 +15,21 @@ void fake_keccakf1600(uint64_t* state) noexcept
 }
 
 
+template <void Fn(uint64_t*)>
 static void keccakf1600(benchmark::State& state)
 {
     uint64_t keccak_state[25] = {};
 
     for (auto _ : state)
     {
-        ethash_keccakf1600(keccak_state);
+        Fn(keccak_state);
         benchmark::DoNotOptimize(keccak_state);
     }
 }
-BENCHMARK(keccakf1600);
+BENCHMARK_TEMPLATE(keccakf1600, ethash_keccakf1600);
+#if defined(__x86_64__) && __has_attribute(target)
+BENCHMARK_TEMPLATE(keccakf1600, ethash_keccakf1600_bmi);
+#endif
 
 
 static void keccakf800(benchmark::State& state)
@@ -71,7 +73,7 @@ static void keccak512(benchmark::State& state)
 BENCHMARK(keccak512)->Arg(32)->Arg(64)->Arg(71)->Arg(72)->Arg(142)->Arg(143)->Arg(144);
 
 
-template<void keccak_fn(uint64_t*, const uint8_t*, size_t)>
+template <void keccak_fn(uint64_t*, const uint8_t*, size_t)>
 static void fake_keccak256(benchmark::State& state)
 {
     std::vector<uint8_t> data(static_cast<size_t>(state.range(0)), 0xaa);
@@ -88,7 +90,7 @@ BENCHMARK_TEMPLATE(fake_keccak256, fake_keccak256_default)->Arg(128)->Arg(17 * 8
 BENCHMARK_TEMPLATE(fake_keccak256, fake_keccak256_fastest)->Arg(128)->Arg(17 * 8)->Arg(4096)->Arg(16 * 1024);
 
 
-template<void keccak_fn(uint64_t*, const uint8_t*, size_t)>
+template <void keccak_fn(uint64_t*, const uint8_t*, size_t)>
 static void fake_keccak256_unaligned(benchmark::State& state)
 {
     const auto size = static_cast<size_t>(state.range(0));


### PR DESCRIPTION
Using BMI and BMI2 instruction set extensions makes Keccak 25% faster.