### PR TITLE
keccak: Fix __builtin_memcpy detection

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -299,7 +299,7 @@ jobs:
 
   macos-xcode-tsan:
     macos:
-      xcode: "12.4.0"
+      xcode: "12.5.1"
     environment:
       - BUILD_PARALLEL_JOBS: 4
       - CMAKE_OPTIONS: -DSANITIZE=thread
@@ -309,7 +309,7 @@ jobs:
 
   macos-xcode-old:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.2.1"
     environment:
       - BUILD_PARALLEL_JOBS: 4
     steps:
@@ -317,7 +317,7 @@ jobs:
 
   macos-release:
     macos:
-      xcode: "12.4.0"
+      xcode: "12.5.1"
     environment:
       - BUILD_PARALLEL_JOBS: 4
       - CMAKE_OPTIONS: -DETHASH_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=~/project/dist

--- a/lib/keccak/keccak.c
+++ b/lib/keccak/keccak.c
@@ -5,7 +5,7 @@
 #include "../support/attributes.h"
 #include <ethash/keccak.h>
 
-#if defined(_MSC_VER)
+#if !__has_builtin(__builtin_memcpy) && !defined(__GNUC__)
 #include <string.h>
 #define __builtin_memcpy memcpy
 #endif

--- a/lib/support/attributes.h
+++ b/lib/support/attributes.h
@@ -9,6 +9,11 @@
 #define __has_attribute(name) 0
 #endif
 
+// Provide __has_builtin macro if not defined.
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
 // [[always_inline]]
 #if _MSC_VER
 #define ALWAYS_INLINE __forceinline


### PR DESCRIPTION
Improve rules for __builtin_memcpy detection. Previous conditions were
failing when building with clang-cl.