### PR TITLE
Remove compute_dataset_item_512()

### DIFF
--- a/lib/ethash/ethash-internal.hpp
+++ b/lib/ethash/ethash-internal.hpp
@@ -49,7 +49,6 @@ bool check_against_difficulty(const hash256& final_hash, const hash256& difficul
 
 void build_light_cache(hash512 cache[], int num_items, const hash256& seed) noexcept;
 
-hash512 calculate_dataset_item_512(const epoch_context& context, int64_t index) noexcept;
 hash1024 calculate_dataset_item_1024(const epoch_context& context, uint32_t index) noexcept;
 
 namespace generic

--- a/lib/ethash/ethash.cpp
+++ b/lib/ethash/ethash.cpp
@@ -201,18 +201,10 @@ struct item_state
     ALWAYS_INLINE hash512 final() noexcept { return keccak512(le::uint32s(mix)); }
 };
 
-hash512 calculate_dataset_item_512(const epoch_context& context, int64_t index) noexcept
-{
-    item_state item0{context, index};
-    for (uint32_t j = 0; j < full_dataset_item_parents; ++j)
-        item0.update(j);
-    return item0.final();
-}
-
-/// Calculates a full dataset item
+/// Calculates a full dataset item.
 ///
-/// This consist of two 512-bit items produced by calculate_dataset_item_partial().
-/// Here the computation is done interleaved for better performance.
+/// This consist of two 512-bit items defined by the Ethash specification, but these items
+/// are never needed separately. Here the computation is done interleaved for better performance.
 hash1024 calculate_dataset_item_1024(const epoch_context& context, uint32_t index) noexcept
 {
     item_state item0{context, int64_t(index) * 2};

--- a/test/benchmarks/ethash_benchmarks.cpp
+++ b/test/benchmarks/ethash_benchmarks.cpp
@@ -79,19 +79,6 @@ BENCHMARK(create_context)->Arg(1)->Unit(benchmark::kMillisecond);
 BENCHMARK(create_context)->Arg(333)->Unit(benchmark::kMillisecond);
 
 
-static void ethash_calculate_dataset_item_512(benchmark::State& state)
-{
-    auto& ctx = get_ethash_epoch_context_0();
-
-    for (auto _ : state)
-    {
-        auto item = ethash::calculate_dataset_item_512(ctx, 1234);
-        benchmark::DoNotOptimize(item.bytes);
-    }
-}
-BENCHMARK(ethash_calculate_dataset_item_512);
-
-
 static void ethash_calculate_dataset_item_1024(benchmark::State& state)
 {
     auto& ctx = get_ethash_epoch_context_0();

--- a/test/unittests/test_ethash.cpp
+++ b/test/unittests/test_ethash.cpp
@@ -476,12 +476,6 @@ TEST(ethash, fake_dataset_items)
         const hash1024 item1024 = calculate_dataset_item_1024(*context, t.index);
         EXPECT_EQ(to_hex(item1024.hash512s[0]), t.hash1_hex) << "index: " << t.index;
         EXPECT_EQ(to_hex(item1024.hash512s[1]), t.hash2_hex) << "index: " << t.index;
-
-        const hash512 item512_0 = calculate_dataset_item_512(*context, int64_t(t.index) * 2);
-        EXPECT_EQ(to_hex(item512_0), t.hash1_hex) << "index: " << t.index;
-
-        const hash512 item512_1 = calculate_dataset_item_512(*context, int64_t(t.index) * 2 + 1);
-        EXPECT_EQ(to_hex(item512_1), t.hash2_hex) << "index: " << t.index;
     }
 }
 


### PR DESCRIPTION
The Ethash spec defines the full dataset (DAG) in terms of 512-bit
items. However, the items are always used in pairs. The implementation
always uses calculate_dataset_item_1024() and
calculate_dataset_item_512() was only used in tests.