### PR TITLE
Update Hunter to v0.24.0 and remove GTest config

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -3,16 +3,6 @@
 # Licensed under the Apache License, Version 2.0.
 
 hunter_config(
-    GTest
-    VERSION 1.11.0
-    URL https://github.com/google/googletest/archive/release-1.11.0.tar.gz
-    SHA1 7b100bb68db8df1060e178c495f3cbe941c9b058
-    CMAKE_ARGS
-    HUNTER_INSTALL_LICENSE_FILES=LICENSE
-    gtest_force_shared_crt=TRUE
-)
-
-hunter_config(
     benchmark
     VERSION 1.6.0
     URL https://github.com/google/benchmark/archive/refs/tags/v1.6.0.tar.gz

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -11,7 +11,7 @@ if(NOT WIN32)
 endif()
 
 HunterGate(
-    URL https://github.com/cpp-pm/hunter/archive/v0.23.239.tar.gz
-    SHA1 135567a8493ab3499187bce1f2a8df9b449febf3
+    URL "https://github.com/cpp-pm/hunter/archive/v0.24.0.tar.gz"
+    SHA1 "a3d7f4372b1dcd52faa6ff4a3bd5358e1d0e5efd"
     LOCAL
 )


### PR DESCRIPTION
as 1.11.0 is default since Hunter v0.23.307

Someone with Windows machine please test, I could only test it briefly on a collegue's windows machine.