### PR TITLE
Add a missing space to `README.md` and remove from table of contents the removed `Test vectors` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [ethash.hpp] for a list of exported functions and documentation.
 This section describes the optimizations, modifications and tweaks applied
 in this library in relation to [Ethash reference implementation].
 
-The library contains a set of micro-benchmarks.Build and run the `ethash-bench`
+The library contains a set of micro-benchmarks. Build and run the `ethash-bench`
 tool.
 
 ### Seed hash is computed on the fly.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 - [Install](#install)
 - [Usage](#usage)
-- [Test vectors](#test-vectors)
 - [Optimizations](#optimizations)
 - [Maintainer](#maintainer)
 - [License](#license)


### PR DESCRIPTION
The `Test vectors` section was forgot to be removed in https://github.com/chfast/ethash/commit/cdef24d186e3dfbf53fed75d1f276a12cedbe2cf#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5.