### PR TITLE
Add python type annotations

### DIFF
--- a/bindings/python/ethash/__init__.py
+++ b/bindings/python/ethash/__init__.py
@@ -1,21 +1,36 @@
 # ethash: C/C++ implementation of Ethash, the Ethereum Proof of Work algorithm.
 # Copyright 2019 Pawel Bylica.
+# Copyright 2023 Sam Wilson.
 # Licensed under the Apache License, Version 2.0.
 
-from _ethash import ffi, lib
+from _ethash import ffi, lib  # type: ignore
+
+from typing import TYPE_CHECKING, Tuple
+
+from collections.abc import Sized
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    from _typeshed import ReadableBuffer
+
+    class SizedReadableBuffer(Protocol, ReadableBuffer, Sized):
+        pass
 
 
-def keccak_256(data):
+def keccak_256(data: "SizedReadableBuffer") -> bytes:
     hash = lib.ethash_keccak256(ffi.from_buffer(data), len(data))
     return ffi.unpack(hash.str, len(hash.str))
 
 
-def keccak_512(data):
+def keccak_512(data: "SizedReadableBuffer") -> bytes:
     hash = lib.ethash_keccak512(ffi.from_buffer(data), len(data))
     return ffi.unpack(hash.str, len(hash.str))
 
 
-def hash(epoch_number, header_hash, nonce):
+def hash(
+    epoch_number: int, header_hash: "SizedReadableBuffer", nonce: int
+) -> Tuple[bytes, bytes]:
     if len(header_hash) != 32:
         raise ValueError('header_hash must have length of 32')
 
@@ -28,7 +43,13 @@ def hash(epoch_number, header_hash, nonce):
     return final_hash, mix_hash
 
 
-def verify(epoch_number, header_hash, mix_hash, nonce, boundary):
+def verify(
+    epoch_number: int,
+    header_hash: "SizedReadableBuffer",
+    mix_hash: "SizedReadableBuffer",
+    nonce: int,
+    boundary: "SizedReadableBuffer",
+) -> bool:
     if len(header_hash) != 32:
         raise ValueError('header_hash must have length of 32')
     if len(mix_hash) != 32:

--- a/bindings/python/ethash/__init__.py
+++ b/bindings/python/ethash/__init__.py
@@ -19,13 +19,13 @@ if TYPE_CHECKING:
 
 
 def keccak_256(data: "SizedReadableBuffer") -> bytes:
-    hash = lib.ethash_keccak256(ffi.from_buffer(data), len(data))
-    return ffi.unpack(hash.str, len(hash.str))
+    h = lib.ethash_keccak256(ffi.from_buffer(data), len(data))
+    return ffi.unpack(h.str, len(h.str))
 
 
 def keccak_512(data: "SizedReadableBuffer") -> bytes:
-    hash = lib.ethash_keccak512(ffi.from_buffer(data), len(data))
-    return ffi.unpack(hash.str, len(hash.str))
+    h = lib.ethash_keccak512(ffi.from_buffer(data), len(data))
+    return ffi.unpack(h.str, len(h.str))
 
 
 def hash(

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
 
     package_dir={'': 'bindings/python'},
     packages=['ethash'],
+    package_data={'ethash': ['py.typed']},
     cffi_modules=['bindings/python/ethash/_build.py:ffibuilder'],
 
     python_requires='>=3.6',


### PR DESCRIPTION
Not 100% sure it's safe to use `ReadableBuffer`. I'm guessing that `.str = data` makes a copy, unlike `ffi.from_buffer`?